### PR TITLE
Add OnDemand portal namespace configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Made currently installed version number of OnDemand available to all PUNs if
   the OnDemand version file exists.
   [#36](https://github.com/OSC/nginx_stage/issues/36)
+- Can specify portal name to namespace multiple OnDemand hosted portals.
 
 ## [0.4.0] - 2018-02-09
 ### Added

--- a/lib/nginx_stage.rb
+++ b/lib/nginx_stage.rb
@@ -49,6 +49,21 @@ module NginxStage
     nil
   end
 
+  # The unique name of the hosted OnDemand portal used to namespace apps, their
+  # data, and logging information
+  # @example No OnDemand Portal name specified
+  #   portal #=> "ondemand"
+  # @example The AweSim portal is specified
+  #   portal #=> "awesim"
+  # @return [String] unique portal name
+  def self.portal
+    if ondemand_portal.to_s.strip.empty?
+      "ondemand"
+    else
+      ondemand_portal.strip.downcase.gsub(/\s+/, "_")
+    end
+  end
+
   # Regex used to parse an app request
   # @example Dev app request
   #   parse_app_request(request: '/dev/rails1/structure/1')
@@ -70,6 +85,21 @@ module NginxStage
     end
     raise InvalidRequest, "invalid request: #{request}" if app_info.empty?
     app_info
+  end
+
+  # Environment used during execution of nginx binary
+  # @example Start the per-user NGINX for user Bob
+  #   nginx_env(user: 'bob')
+  #   #=> { "USER" => "bob", ... }
+  # @param user [String] the owner of the nginx process
+  # @return [Hash{String=>String}] the environment used to execute the nginx process
+  def self.nginx_env(user:)
+    {
+      "USER" => user,
+      "ONDEMAND_VERSION" => ondemand_version,
+      "ONDEMAND_PORTAL" => portal,
+      "OOD_PORTAL" => ondemand_portal, # backwards compatible
+    }
   end
 
   # Arguments used during execution of nginx binary

--- a/lib/nginx_stage/configuration.rb
+++ b/lib/nginx_stage/configuration.rb
@@ -13,6 +13,10 @@ module NginxStage
     # @return [String] the ondemand version file
     attr_accessor :ondemand_version_path
 
+    # Unique name of OnDemand portal for namespacing multiple portals
+    # @return [String, nil] the name of OnDemand portal if defined
+    attr_accessor :ondemand_portal
+
     # Location of ERB templates used as NGINX configs
     # @return [String] the ERB templates root path
     attr_accessor :template_root
@@ -207,7 +211,7 @@ module NginxStage
       File.expand_path(
         @app_root.fetch(env) do
           raise InvalidRequest, "invalid request environment: #{env}"
-        end % {env: env, owner: owner, name: name}
+        end % {env: env, owner: owner, name: name, portal: portal}
       )
     end
 
@@ -336,6 +340,7 @@ module NginxStage
     # @return [void]
     def set_default_configuration
       self.ondemand_version_path = "/opt/ood/VERSION"
+      self.ondemand_portal       = nil
       self.template_root         = "#{root}/templates"
 
       self.proxy_user       = 'apache'
@@ -367,7 +372,7 @@ module NginxStage
         sys: '/var/lib/nginx/config/apps/sys/%{name}.conf'
       }
       self.app_root          = {
-        dev: '~%{owner}/ondemand/dev/%{name}',
+        dev: '~%{owner}/%{portal}/dev/%{name}',
         usr: '/var/www/ood/apps/usr/%{owner}/gateway/%{name}',
         sys: '/var/www/ood/apps/sys/%{name}'
       }

--- a/lib/nginx_stage/generators/app_config_generator.rb
+++ b/lib/nginx_stage/generators/app_config_generator.rb
@@ -79,10 +79,24 @@ module NginxStage
     add_hook :exec_nginx do
       if !skip_nginx
         if File.file? NginxStage.pun_pid_path(user: user)
-          o, s = Open3.capture2e([NginxStage.nginx_bin, "(#{user})"], *NginxStage.nginx_args(user: user, signal: :stop))
+          o, s = Open3.capture2e(
+            NginxStage.nginx_env(user: user),
+            [
+              NginxStage.nginx_bin,
+              "(#{user})"
+            ],
+            *NginxStage.nginx_args(user: user, signal: :stop)
+          )
           abort(o) unless s.success?
         end
-        o, s = Open3.capture2e([NginxStage.nginx_bin, "(#{user})"], *NginxStage.nginx_args(user: user))
+        o, s = Open3.capture2e(
+          NginxStage.nginx_env(user: user),
+          [
+            NginxStage.nginx_bin,
+            "(#{user})"
+          ],
+          *NginxStage.nginx_args(user: user)
+        )
         s.success? ? exit : abort(o)
       end
     end

--- a/lib/nginx_stage/generators/nginx_clean_generator.rb
+++ b/lib/nginx_stage/generators/nginx_clean_generator.rb
@@ -49,7 +49,7 @@ module NginxStage
             puts u
             if !skip_nginx
               o, s = Open3.capture2e(
-                NginxStage.nginx_env(user: user),
+                NginxStage.nginx_env(user: u),
                 NginxStage.nginx_bin,
                 *NginxStage.nginx_args(user: u, signal: :stop)
               )

--- a/lib/nginx_stage/generators/nginx_clean_generator.rb
+++ b/lib/nginx_stage/generators/nginx_clean_generator.rb
@@ -48,7 +48,11 @@ module NginxStage
           if socket.sessions.zero? || force
             puts u
             if !skip_nginx
-              o, s = Open3.capture2e(NginxStage.nginx_bin, *NginxStage.nginx_args(user: u, signal: :stop))
+              o, s = Open3.capture2e(
+                NginxStage.nginx_env(user: user),
+                NginxStage.nginx_bin,
+                *NginxStage.nginx_args(user: u, signal: :stop)
+              )
               $stderr.puts o unless s.success?
             end
           end

--- a/lib/nginx_stage/generators/nginx_process_generator.rb
+++ b/lib/nginx_stage/generators/nginx_process_generator.rb
@@ -34,7 +34,14 @@ module NginxStage
     # Run the per-user NGINX process (exit quietly on success)
     add_hook :exec_nginx do
       if !skip_nginx
-        o, s = Open3.capture2e([NginxStage.nginx_bin, "(#{user})"], *NginxStage.nginx_args(user: user, signal: signal))
+        o, s = Open3.capture2e(
+          NginxStage.nginx_env(user: user),
+          [
+            NginxStage.nginx_bin,
+            "(#{user})"
+          ],
+          *NginxStage.nginx_args(user: user, signal: signal)
+        )
         s.success? ? exit : abort(o)
       end
     end

--- a/lib/nginx_stage/generators/pun_config_generator.rb
+++ b/lib/nginx_stage/generators/pun_config_generator.rb
@@ -82,7 +82,14 @@ module NginxStage
     # Run the per-user NGINX process (exit quietly on success)
     add_hook :exec_nginx do
       if !skip_nginx
-        o, s = Open3.capture2e([NginxStage.nginx_bin, "(#{user})"], *NginxStage.nginx_args(user: user))
+        o, s = Open3.capture2e(
+          NginxStage.nginx_env(user: user),
+          [
+            NginxStage.nginx_bin,
+            "(#{user})"
+          ],
+          *NginxStage.nginx_args(user: user)
+        )
         s.success? ? exit : abort(o)
       end
     end

--- a/lib/nginx_stage/views/pun_config_view.rb
+++ b/lib/nginx_stage/views/pun_config_view.rb
@@ -1,12 +1,6 @@
 module NginxStage
   # A view used as context for the pun config ERB template file
   module PunConfigView
-    # Current version of installed OnDemand
-    # @return [String, nil] version of OnDemand
-    def ondemand_version
-      NginxStage.ondemand_version
-    end
-
     # Primary group of the user
     # @return [String] primary group of user
     def group

--- a/share/nginx_stage_example.yml
+++ b/share/nginx_stage_example.yml
@@ -18,6 +18,11 @@
 #
 #ondemand_version_path: '/opt/ood/VERSION'
 
+# Unique name of this OnDemand portal used to namespace multiple hosted portals
+# NB: If this is not set then most apps will use default namespace "ondemand"
+#
+#ondemand_portal: null
+
 # Location of the ERB templates used in the generation of the NGINX configs
 #
 #template_root: '/opt/ood/nginx_stage/templates'
@@ -119,7 +124,7 @@
 # corresponding environment
 #
 #app_root:
-#  dev: '~%{owner}/ondemand/dev/%{name}'
+#  dev: '~%{owner}/%{portal}/dev/%{name}'
 #  usr: '/var/www/ood/apps/usr/%{owner}/gateway/%{name}'
 #  sys: '/var/www/ood/apps/sys/%{name}'
 

--- a/templates/pun.conf.erb
+++ b/templates/pun.conf.erb
@@ -1,9 +1,3 @@
-# Setup environment
-env USER=<%= user %>;
-<%- if ondemand_version -%>
-env ONDEMAND_VERSION=<%= ondemand_version %>;
-<%- end -%>
-
 user        <%= user %> <%= group %>;  ## Default: nobody
 error_log   <%= error_log_path %>;
 pid         <%= pid_path %>;


### PR DESCRIPTION
An admin can now add a configuration option `ondemand_portal` with a unique name to namespace their OnDemand portal. This does:

- changes sandbox app location to `~<user>/<portal>/dev`
- sets `ONDEMAND_PORTAL` to portal if specified, otherwise it defaults to "ondemand" (I can remove this, but thought it would be nice since it is already available when defining the sandbox app root)
- sets `OOD_PORTAL` to portal if specified otherwise it is left unset

I also changed how environment variables are handled by NGINX. It seems Passenger lets all environment variables through, whereas NGINX needs them specified in the config.