### PR TITLE
Handle spaces in domain groups correctly

### DIFF
--- a/templates/pun.conf.erb
+++ b/templates/pun.conf.erb
@@ -1,4 +1,4 @@
-user        <%= user %> <%= group %>;  ## Default: nobody
+user        <%= user %> '<%= group %>';  ## Default: nobody
 error_log   <%= error_log_path %>;
 pid         <%= pid_path %>;
 worker_processes 1;  ## Default: 1


### PR DESCRIPTION
Previous version of this file wouldn't handle spaces in a group - for example if a user had "domain users" as their group, it would fail to start up nginx with an 'incorrect number of arguments' error. Adding the single quotes around this fixes that.